### PR TITLE
Update image features

### DIFF
--- a/pande_gas/features/images.py
+++ b/pande_gas/features/images.py
@@ -21,15 +21,16 @@ class MolImage(Featurizer):
 
     Parameters
     ----------
-    shape : tuple of ints, optional
-        Shape of generated images.
-    flatten : bool, optional (default False)
-        Whether to flatten the pixel array.
+    max_size : int, optional (default 32)
+        Maximum size (in any dimension) of generated images.
+    flatten : bool, optional (default True)
+        Whether to flatten the pixel array. If False, the features for each
+        molecule will be a 3D array.
     """
     name = 'image'
 
-    def __init__(self, shape=None, flatten=True):
-        self.shape = shape
+    def __init__(self, max_size=32, flatten=True):
+        self.shape = (max_size, max_size)
         if not flatten:
             self.topo_view = True
         self.flatten = flatten

--- a/pande_gas/features/tests/test_images.py
+++ b/pande_gas/features/tests/test_images.py
@@ -9,16 +9,16 @@ from pande_gas.features import images
 def test_images():
     """Test MolImage."""
     mol = Chem.MolFromSmiles(test_smiles)
-    f = images.MolImage(shape=(200, 250))
+    f = images.MolImage(250)
     rval = f([mol])
-    assert rval.shape == (1, 200 * 250 * 3)
+    assert rval.shape == (1, 250 * 250 * 3)
 
 
 def test_images_topo_view():
     """Test MolImage using topo_view."""
     mol = Chem.MolFromSmiles(test_smiles)
-    f = images.MolImage(shape=(200, 250), flatten=False)
+    f = images.MolImage(250, flatten=False)
     rval = f([mol])
-    assert rval.shape == (1, 200, 250, 3)
+    assert rval.shape == (1, 250, 250, 3)
 
 test_smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O'


### PR DESCRIPTION
Changes:
- Use `max_size` instead of `shape`, so the featurize.py script will work properly.
- Set a default `max_size` so downscale and pad functions in _featurize won't fail.
