### PR TITLE
Fix image subprocess usage

### DIFF
--- a/pande_gas/features/images.py
+++ b/pande_gas/features/images.py
@@ -63,10 +63,10 @@ class MolImage(Featurizer):
         smiles : str
             SMILES string.
         """
-        devnull = open(os.devnull, 'w')
         png_args = ['obabel', '-ican', '-opng', '-xd', '-xC',
                     '-xp {}'.format(self.size)]
-        p = subprocess.Popen(png_args, stdin=subprocess.PIPE, stderr=devnull)
+        p = subprocess.Popen(png_args, stdin=subprocess.PIPE, 
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         png, _ = p.communicate(smiles)
         im = image_utils.load(png)
         return im

--- a/pande_gas/features/tests/test_images.py
+++ b/pande_gas/features/tests/test_images.py
@@ -9,9 +9,9 @@ from pande_gas.features import images
 def test_images():
     """Test MolImage."""
     mol = Chem.MolFromSmiles(test_smiles)
-    f = images.MolImage(250)
+    f = images.MolImage(250, flatten=True)
     rval = f([mol])
-    assert rval.shape == (1, 250 * 250 * 3)
+    assert rval.shape == (1, 250 * 250 * 3), rval.shape
 
 
 def test_images_topo_view():
@@ -19,6 +19,6 @@ def test_images_topo_view():
     mol = Chem.MolFromSmiles(test_smiles)
     f = images.MolImage(250, flatten=False)
     rval = f([mol])
-    assert rval.shape == (1, 250, 250, 3)
+    assert rval.shape == (1, 250, 250, 3), rval.shape
 
 test_smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O'


### PR DESCRIPTION
- Clean up the use of `subprocess` significantly, and use `Popen.communicate` to make sure that Python waits for the child to exit before moving on.
- Modify the image tests to account for changing the default to `flatten=False`.
