### PR TITLE
Fix default argument

### DIFF
--- a/pande_gas/features/fingerprints.py
+++ b/pande_gas/features/fingerprints.py
@@ -19,7 +19,7 @@ class CircularFingerprint(Featurizer):
     ----------
     radius : int, optional (default 2)
         Fingerprint radius.
-    size : int, optional (default 1024)
+    size : int, optional (default 2048)
         Length of generated bit vector.
     chiral : bool, optional (default False)
         Whether to consider chirality in fingerprint generation.
@@ -31,7 +31,7 @@ class CircularFingerprint(Featurizer):
     """
     name = 'circular'
 
-    def __init__(self, radius=2, size=1024, chiral=False, bonds=True,
+    def __init__(self, radius=2, size=2048, chiral=False, bonds=True,
                  features=False):
         self.radius = radius
         self.size = size


### PR DESCRIPTION
The `bonds` argument default for CircularFingerprint was set incorrectly (does not match http://www.rdkit.org/Python_Docs/rdkit.Chem.rdMolDescriptors-module.html#GetMorganFingerprintAsBitVect). 

I can regenerate the fingerprints for the MUV datasets.

Note: we are also currently using vector sizes of 1024 instead of the default 2048. If we are worried at all about collisions it might be wise to use the larger value. Let me know.
