### PR TITLE
Target collation

### DIFF
--- a/pande_gas/scripts/tests/test_featurize.py
+++ b/pande_gas/scripts/tests/test_featurize.py
@@ -376,6 +376,8 @@ class TestFeaturize(unittest.TestCase):
         with open(output_filename) as f:
             data = cPickle.load(f)
 
-        assert np.array_equal(data['names'], targets['names'])
-        assert np.array_equal(data['y'], targets['y'])
+        sort = np.argsort(targets['names'])  # names will be sorted
+        assert np.array_equal(data['names'],
+                              np.asarray(targets['names'])[sort])
+        assert np.array_equal(data['y'], np.asarray(targets['y'])[sort])
         assert data['features'].shape[0] == 2


### PR DESCRIPTION
The NCGC datasets don't have target values for all of the molecules I downloaded from PubChem, so this PR adds some methods to featurize.py for collating molecules and targets. The target_filename passed to the script can be either a pickled array of targets in the same order as the molecules (the current approach), or a pickled dict containing 'names' and 'y' keys, which correspond to molecule names and targets, respectively. In this latter case with a pickled dict, the molecules and targets are then collated to be sure that each molecule that is featurized is associated with a target.

Also, I moved the scaffold generation code into its own method so scaffolds will not be calculated for molecules that are dropped during the molecule/target collation process.
