### PR TITLE
Fix image bug

### DIFF
--- a/pande_gas/features/images.py
+++ b/pande_gas/features/images.py
@@ -50,6 +50,7 @@ class MolImage(Featurizer):
             image = ob_utils.MolImage(self.size)(mol)
         elif self.engine == 'rdkit':
             image = Draw.MolToImage(mol, dim, fitImage=True)
+            image = image.convert('RGB')  # drop alpha channel
         else:
             raise NotImplementedError(self.engine)
         pixels = image_utils.get_pixels(image)


### PR DESCRIPTION
Just a quick fix so all the tests pass. These image tests when using the `rdkit` engine (the `obabel` engine makes much nicer images) were failing due to the alpha channel. 
