### PR TITLE
Add get_class_data.py

### DIFF
--- a/vs_utils/scripts/public_data/get_class_data.py
+++ b/vs_utils/scripts/public_data/get_class_data.py
@@ -33,20 +33,20 @@ def parse_args(input_args=None):
   return parser.parse_args(input_args)
 
 
-def get_rows(reader, outcome, assay, target, with_aid=True, with_target=True,
-             phenotype=None, join=False):
+def get_rows(reader, outcome, assay_id, target, with_assay_id=True,
+             with_target=True, phenotype=None, join=False):
   """Get a row for each data point."""
   rows = []
-  cids = set()
+  mol_ids = set()
   mols = set()
   for mol in reader:
-    row = {'id': mol.GetProp('_Name'), 'outcome': outcome}
-    if join and row['id'] in cids:
+    row = {'mol_id': mol.GetProp('_Name'), 'outcome': outcome}
+    if join and row['mol_id'] in mol_ids:
       continue
-    cids.add(row['id'])
+    mol_ids.add(row['mol_id'])
     mols.add(mol)
-    if with_aid:
-      row['assay'] = assay
+    if with_assay_id:
+      row['assay_id'] = assay_id
     if with_target:
       row['target'] = target
     if phenotype is not None:
@@ -55,7 +55,7 @@ def get_rows(reader, outcome, assay, target, with_aid=True, with_target=True,
   return rows, mols
 
 
-def main(active_filename, decoy_filename, assay, target, with_assay=True,
+def main(active_filename, decoy_filename, assay_id, target, with_assay_id=True,
          with_target=True, phenotype=None, join=False, output_filename=None,
          unique_filename=None):
   rows = []
@@ -66,17 +66,17 @@ def main(active_filename, decoy_filename, assay, target, with_assay=True,
     if outcome == 'inactive' and phenotype is not None:
       this_phenotype = 'inactive'
     with serial.MolReader().open(filename) as reader:
-      this_rows, this_mols = get_rows(reader, outcome, assay, target,
-                                      with_assay, with_target, this_phenotype,
-                                      join)
+      this_rows, this_mols = get_rows(reader, outcome, assay_id, target,
+                                      with_assay_id, with_target,
+                                      this_phenotype, join)
       rows.extend(this_rows)
       mols.extend(this_mols)
   assert len(rows) == len(mols)
 
   df = pd.DataFrame(rows)
   if output_filename is None:
-    output_filename = '{}-{}-data.pkl.gz'.format(aid, target)
-  print '{}\t{}\t{}\t{}'.format(assay, target, output_filename, len(df))
+    output_filename = '{}-data.pkl.gz'.format(assay_id)
+  print '{}\t{}\t{}\t{}'.format(assay_id, target, output_filename, len(df))
   utils.write_pickle(df, output_filename)
 
   if unique_filename is not None:

--- a/vs_utils/scripts/public_data/get_class_data.py
+++ b/vs_utils/scripts/public_data/get_class_data.py
@@ -1,0 +1,88 @@
+"""Build data frames for non-PCBA classification datasets."""
+import argparse
+import pandas as pd
+
+from vs_utils import utils
+
+from vs_utils.utils.rdkit_utils import serial
+
+
+def parse_args(input_args=None):
+  """Parse command-line arguments."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--aid', required=1,
+                      help='Assay ID.')
+  parser.add_argument('--target', required=1,
+                      help='Assay target.')
+  parser.add_argument('-a', '--actives', required=1,
+                      help='File containing actives.')
+  parser.add_argument('-d', '--decoys', required=1,
+                      help='File containing decoys.')
+  parser.add_argument('--no-aid', action='store_false', dest='with_aid',
+                      help='Do not include AID with each data point.')
+  parser.add_argument('--no-target', action='store_false', dest='with_target',
+                      help='Do not include target with each data point.')
+  parser.add_argument('-j', '--join', action='store_true',
+                      help='Join duplicated molecules.')
+  parser.add_argument('--phenotype',
+                      help='Phenotype for actives in this assay.')
+  parser.add_argument('-o', '--output',
+                      help='Output filename.')
+  parser.add_argument('--mols',
+                      help='Filename to write unique molecules.')
+  return parser.parse_args(input_args)
+
+
+def get_rows(reader, outcome, aid, target, with_aid=True, with_target=True,
+             phenotype=None, join=False):
+  """Get a row for each data point."""
+  rows = []
+  cids = set()
+  mols = set()
+  for mol in reader:
+    row = {'cid': mol.GetProp('_Name'), 'outcome': outcome}
+    if join and row['cid'] in cids:
+      continue
+    cids.add(row['cid'])
+    mols.add(mol)
+    if with_aid:
+      row['aid'] = aid
+    if with_target:
+      row['target'] = target
+    if phenotype is not None:
+      row['phenotype'] = phenotype
+    rows.append(row)
+  return rows, mols
+
+
+def main(active_filename, decoy_filename, aid, target, with_aid=True,
+         with_target=True, phenotype=None, join=False, output_filename=None,
+         unique_filename=None):
+  rows = []
+  mols = []
+  for outcome, filename in zip(['active', 'inactive'],
+                               [active_filename, decoy_filename]):
+    this_phenotype = phenotype
+    if outcome == 'inactive' and phenotype is not None:
+      this_phenotype = 'inactive'
+    with serial.MolReader().open(filename) as reader:
+      this_rows, this_mols = get_rows(reader, outcome, aid, target, with_aid,
+                                      with_target, this_phenotype, join)
+      rows.extend(this_rows)
+      mols.extend(this_mols)
+  assert len(rows) == len(mols)
+
+  df = pd.DataFrame(rows)
+  if output_filename is None:
+    output_filename = '{}-{}-data.pkl.gz'.format(aid, target)
+  print '{}\t{}\t{}\t{}'.format(aid, target, output_filename, len(df))
+  utils.write_pickle(df, output_filename)
+
+  if unique_filename is not None:
+    with serial.MolWriter().open(unique_filename) as writer:
+      writer.write(mols)
+
+if __name__ == '__main__':
+  args = parse_args()
+  main(args.actives, args.decoys, args.aid, args.target, args.with_aid,
+       args.with_target, args.phenotype, args.join, args.output, args.mols)

--- a/vs_utils/scripts/public_data/get_class_data.py
+++ b/vs_utils/scripts/public_data/get_class_data.py
@@ -10,7 +10,7 @@ from vs_utils.utils.rdkit_utils import serial
 def parse_args(input_args=None):
   """Parse command-line arguments."""
   parser = argparse.ArgumentParser()
-  parser.add_argument('--aid', required=1,
+  parser.add_argument('--assay', required=1,
                       help='Assay ID.')
   parser.add_argument('--target', required=1,
                       help='Assay target.')
@@ -18,7 +18,7 @@ def parse_args(input_args=None):
                       help='File containing actives.')
   parser.add_argument('-d', '--decoys', required=1,
                       help='File containing decoys.')
-  parser.add_argument('--no-aid', action='store_false', dest='with_aid',
+  parser.add_argument('--no-assay', action='store_false', dest='with_assay',
                       help='Do not include AID with each data point.')
   parser.add_argument('--no-target', action='store_false', dest='with_target',
                       help='Do not include target with each data point.')
@@ -33,20 +33,20 @@ def parse_args(input_args=None):
   return parser.parse_args(input_args)
 
 
-def get_rows(reader, outcome, aid, target, with_aid=True, with_target=True,
+def get_rows(reader, outcome, assay, target, with_aid=True, with_target=True,
              phenotype=None, join=False):
   """Get a row for each data point."""
   rows = []
   cids = set()
   mols = set()
   for mol in reader:
-    row = {'cid': mol.GetProp('_Name'), 'outcome': outcome}
-    if join and row['cid'] in cids:
+    row = {'id': mol.GetProp('_Name'), 'outcome': outcome}
+    if join and row['id'] in cids:
       continue
-    cids.add(row['cid'])
+    cids.add(row['id'])
     mols.add(mol)
     if with_aid:
-      row['aid'] = aid
+      row['assay'] = assay
     if with_target:
       row['target'] = target
     if phenotype is not None:
@@ -55,7 +55,7 @@ def get_rows(reader, outcome, aid, target, with_aid=True, with_target=True,
   return rows, mols
 
 
-def main(active_filename, decoy_filename, aid, target, with_aid=True,
+def main(active_filename, decoy_filename, assay, target, with_assay=True,
          with_target=True, phenotype=None, join=False, output_filename=None,
          unique_filename=None):
   rows = []
@@ -66,8 +66,9 @@ def main(active_filename, decoy_filename, aid, target, with_aid=True,
     if outcome == 'inactive' and phenotype is not None:
       this_phenotype = 'inactive'
     with serial.MolReader().open(filename) as reader:
-      this_rows, this_mols = get_rows(reader, outcome, aid, target, with_aid,
-                                      with_target, this_phenotype, join)
+      this_rows, this_mols = get_rows(reader, outcome, assay, target,
+                                      with_assay, with_target, this_phenotype,
+                                      join)
       rows.extend(this_rows)
       mols.extend(this_mols)
   assert len(rows) == len(mols)
@@ -75,7 +76,7 @@ def main(active_filename, decoy_filename, aid, target, with_aid=True,
   df = pd.DataFrame(rows)
   if output_filename is None:
     output_filename = '{}-{}-data.pkl.gz'.format(aid, target)
-  print '{}\t{}\t{}\t{}'.format(aid, target, output_filename, len(df))
+  print '{}\t{}\t{}\t{}'.format(assay, target, output_filename, len(df))
   utils.write_pickle(df, output_filename)
 
   if unique_filename is not None:
@@ -84,5 +85,5 @@ def main(active_filename, decoy_filename, aid, target, with_aid=True,
 
 if __name__ == '__main__':
   args = parse_args()
-  main(args.actives, args.decoys, args.aid, args.target, args.with_aid,
+  main(args.actives, args.decoys, args.assay, args.target, args.with_assay,
        args.with_target, args.phenotype, args.join, args.output, args.mols)

--- a/vs_utils/scripts/public_data/get_class_data.py
+++ b/vs_utils/scripts/public_data/get_class_data.py
@@ -1,4 +1,7 @@
-"""Build data frames for non-PCBA classification datasets."""
+"""
+Build data frames for classification datasets with separate files for active
+and inactive molecules (e.g. DUD-E).
+"""
 import argparse
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Add a script to create dataset pickles for classification datasets with separate files for active and inactive molecules (e.g. DUD-E). Uses the more generic "id" and "assay" in place of "cid" and "aid", respectively.

Question: should we use one of {"mol", "mol_id", "mid"} instead of "id" to be more explicit that it refers to a molecule?