### PR TITLE
Use generic molecule and assay ID columns

### DIFF
--- a/vs_utils/scripts/public_data/get_pcba_data.py
+++ b/vs_utils/scripts/public_data/get_pcba_data.py
@@ -119,7 +119,7 @@ def main(dirs, config_filename, map_filename=None, summary_filename=None,
       data = extractor.get_data(sid_cid=sid_cid)
       total += len(data)
 
-      # add generic molecule id column
+      # add generic molecule ID column
       if id_prefix == 'CID':
         col = 'cid'
       elif id_prefix == 'SID':
@@ -127,15 +127,22 @@ def main(dirs, config_filename, map_filename=None, summary_filename=None,
       else:
         raise NotImplementedError('Unrecognized ID prefix "{}"'.format(
             id_prefix))
-      ids = [id_prefix + str(mol_id) for mol_id in data[col]]
+      ids = []
+      for i, mol_id in enumerate(data[col]):
+        try:
+          ids.append(id_prefix + str(int(mol_id)))
+        except ValueError:
+          warnings.warn('No ID for the following row:\n{}'.format(data.loc[i]))
+          ids.append(None)  # can be found with pd.isnull
       data.loc[:, 'mol_id'] = pd.Series(ids, index=data.index)
 
-      # add generic assay id column
+      # add generic assay ID column
+      assay_id = 'PCBA-' + str(aid)
       if with_aid:
-        data.loc[:, 'assay_id'] = 'PCBA' + str(aid)
+        data.loc[:, 'assay_id'] = assay_id
 
       # save dataframe
-      output_filename = 'aid{}-data.pkl.gz'.format(aid)
+      output_filename = '{}.pkl.gz'.format(assay_id)
       print '{}\t{}\t{}\t{}'.format(aid, target, output_filename, len(data))
       summary.append({'aid': aid, 'target': target,
                       'filename': output_filename, 'size': len(data)})

--- a/vs_utils/utils/public_data/__init__.py
+++ b/vs_utils/utils/public_data/__init__.py
@@ -396,11 +396,11 @@ class PcbaDataExtractor(object):
       config['phenotype'] = 'Phenotype'
 
     # target cleanup
-    # add gi: prefix to integer targets
+    # add GI prefix to integer targets
     if 'target' in config:
       try:
         int(config['target'])
-        config['target'] = 'gi_{}'.format(config['target'])
+        config['target'] = 'GI{}'.format(config['target'])
       except ValueError:
         pass
 
@@ -416,7 +416,7 @@ class PcbaDataExtractor(object):
         phenotype = phenotypes[phenotype]  # map to full name
       if phenotype not in phenotypes.itervalues():
         raise NotImplementedError(
-          'Unrecognized phenotype "{}"'.format(phenotype))
+            'Unrecognized phenotype "{}"'.format(phenotype))
       self.phenotype = phenotype  # set default phenotype for this assay
 
     self.config = config

--- a/vs_utils/utils/public_data/__init__.py
+++ b/vs_utils/utils/public_data/__init__.py
@@ -186,7 +186,7 @@ class PcbaJsonParser(object):
       name = field['name'].strip()  # clean up extra whitespace
       if name in names:
         warnings.warn(
-          'Duplicated field "{}" in AID {}'.format(name, self.get_aid()))
+            'Duplicated field "{}" in AID {}'.format(name, self.get_aid()))
       tids[field['tid']] = name
       names.append(name)
     if from_tid:
@@ -221,6 +221,12 @@ class PcbaJsonParser(object):
           point[key] = value
       series.append(point)
     df = pd.DataFrame(series)
+
+    # add missing columns filled with null values
+    for col in tids.itervalues():
+      if col not in df.columns:
+        df.loc[:, col] = None
+
     assert len(df) == len(data)
     self.data = df
     return df


### PR DESCRIPTION
* Add generic mol_id and assay_id columns to PCBA data frames.
* Fix a bug where PCBA columns with no values would be populated with the column name instead of null values.