### PR TITLE
Add code for handling csv IO for features

### DIFF
--- a/vs_utils/scripts/public_data/get_class_data.py
+++ b/vs_utils/scripts/public_data/get_class_data.py
@@ -3,11 +3,11 @@ Build data frames for classification datasets with separate files for active
 and inactive molecules (e.g. DUD-E).
 """
 import argparse
-import gzip
 import numpy as np
 import pandas as pd
 import warnings
 
+from vs_utils.utils import write_dataframe
 from vs_utils.utils.rdkit_utils import serial
 
 
@@ -30,6 +30,10 @@ def parse_args(input_args=None):
                       help='Phenotype for actives in this assay.')
   parser.add_argument('-o', '--output',
                       help='Output filename.')
+  parser.add_argument('-f', '--format',
+                      choices=['csv', 'csv.gz', 'pkl', 'pkl.gz'],
+                      default='pkl.gz',
+                      help='Output file format.')
   parser.add_argument('--mols',
                       help='Filename to write unique molecules.')
   parser.add_argument('--mol-prefix',
@@ -59,7 +63,7 @@ def get_rows(reader, outcome, phenotype=None, mol_id_prefix=None):
 
 def main(active_filename, decoy_filename, assay_id, target, with_assay_id=True,
          with_target=True, phenotype=None, output_filename=None,
-         mol_id_prefix=None):
+         mol_id_prefix=None, output_format='.pkl.gz'):
   rows = []
   for outcome, filename in zip(['active', 'inactive'],
                                [active_filename, decoy_filename]):
@@ -83,13 +87,13 @@ def main(active_filename, decoy_filename, assay_id, target, with_assay_id=True,
     df.loc[:, 'target'] = target
 
   if output_filename is None:
-    output_filename = '{}_data.csv.gz'.format(assay_id)
+    output_filename = '{}.{}'.format(assay_id, output_format)
   print '{}\t{}\t{}\t{}'.format(assay_id, target, output_filename, len(df))
-  with gzip.open(output_filename, 'wb') as f:
-    df.to_csv(f, index=False)
+  write_dataframe(df, output_filename)
 
 if __name__ == '__main__':
   args = parse_args()
   print args
   main(args.actives, args.decoys, args.assay, args.target, args.with_assay,
-       args.with_target, args.phenotype, args.output, args.mol_prefix)
+       args.with_target, args.phenotype, args.output, args.mol_prefix,
+       args.format)

--- a/vs_utils/scripts/tests/test_featurize.py
+++ b/vs_utils/scripts/tests/test_featurize.py
@@ -3,6 +3,7 @@ Test featurize.py.
 """
 import joblib
 import numpy as np
+import pandas as pd
 import shutil
 import tempfile
 import unittest
@@ -11,7 +12,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 from vs_utils.scripts.featurize import main, parse_args
-from vs_utils.utils import read_pickle, write_pickle
+from vs_utils.utils import read_csv_features, read_pickle, write_pickle
 from vs_utils.utils.rdkit_utils import conformers, serial
 
 
@@ -100,6 +101,9 @@ class TestFeaturize(unittest.TestCase):
         # read output file
         if output_filename.endswith('.joblib'):
             data = joblib.load(output_filename)
+        elif (output_filename.endswith('.csv')
+                or output_filename.endswith('.csv.gz')):
+            data = read_csv_features(output_filename)
         else:
             data = read_pickle(output_filename)
 
@@ -112,7 +116,7 @@ class TestFeaturize(unittest.TestCase):
             smiles = self.smiles
         assert len(data) == shape[0]
         if len(shape) > 1:
-            assert data.ix[0, 'features'].shape == shape[1:]
+            assert np.asarray(data.ix[0, 'features']).shape == shape[1:]
         assert np.array_equal(data['y'], targets), data['y']
         assert np.array_equal(data['names'], names), data['names']
         assert np.array_equal(data['smiles'], smiles), data['smiles']
@@ -137,6 +141,18 @@ class TestFeaturize(unittest.TestCase):
         Save features using joblib.dump.
         """
         self.check_output(['circular'], (2, 2048), output_suffix='.joblib')
+
+    def test_csv(self):
+        """
+        Save features to csv.
+        """
+        self.check_output(['circular'], (2, 2048), output_suffix='.csv')
+
+    def test_csv_gz(self):
+        """
+        Save features to csv.gz.
+        """
+        self.check_output(['circular'], (2, 2048), output_suffix='.csv.gz')
 
     def test_circular(self):
         """


### PR DESCRIPTION
* Add special handling of CSV output for features in featurize.py.
* Add a method to vs_utils.utils.\_\_init\_\_.py that can be used to read CSV features (see test_featurize.py for an example). This can be used by people who want to use features in non-Python settings.
* Allow either csv or pkl output for target data and features.