### PR TITLE
Use generic molecule ID in featurization

### DIFF
--- a/vs_utils/scripts/featurize.py
+++ b/vs_utils/scripts/featurize.py
@@ -42,8 +42,8 @@ def parse_args(input_args=None):
     parser.add_argument('--smiles-hydrogens', action='store_true')
     parser.add_argument('--scaffolds', action='store_true',
                         help='Calculate molecule scaffolds.')
-    parser.add_argument('--names', action='store_true',
-                        help='Include molecule names.')
+    parser.add_argument('--smiles', action='store_true', dest='include_smiles',
+                        help='Include molecule SMILES.')
     parser.add_argument('-p', '--parallel', action='store_true',
                         help='Whether to use IPython.parallel.')
     parser.add_argument('-id', '--cluster-id',
@@ -57,6 +57,8 @@ def parse_args(input_args=None):
     parser.add_argument('-c', '--compression-level', type=int, default=3,
                         help='Compression level (0-9) to use with ' +
                              'joblib.dump.')
+    parser.add_argument('--mol-prefix',
+                        help='Prefix for molecule IDs.')
 
     # featurizer subcommands
     featurizers = get_featurizers()
@@ -75,7 +77,7 @@ def parse_args(input_args=None):
                 continue
             kwargs = {}
             try:
-                kwargs['default'] = defaults[i-len(args)]
+                kwargs['default'] = defaults[i - len(args)]
                 if kwargs['default'] is not None:
                     kwargs['type'] = type(kwargs['default'])
             except IndexError:
@@ -93,7 +95,8 @@ def parse_args(input_args=None):
     args.featurizer_kwargs = parser.parse_args(input_args)
     for arg in ['input', 'output', 'klass', 'targets', 'parallel',
                 'cluster_id', 'n_engines', 'compression_level',
-                'smiles_hydrogens', 'names', 'scaffolds', 'chiral_scaffolds']:
+                'smiles_hydrogens', 'include_smiles', 'scaffolds',
+                'chiral_scaffolds', 'mol_prefix']:
         setattr(args, arg, getattr(args.featurizer_kwargs, arg))
         delattr(args.featurizer_kwargs, arg)
     return args
@@ -116,8 +119,8 @@ class HelpFormatter(argparse.RawTextHelpFormatter):
 def main(featurizer_class, input_filename, output_filename,
          target_filename=None, featurizer_kwargs=None, parallel=False,
          client_kwargs=None, view_flags=None, compression_level=3,
-         smiles_hydrogens=False, names=False, scaffolds=False,
-         chiral_scaffolds=False):
+         smiles_hydrogens=False, include_smiles=False, scaffolds=False,
+         chiral_scaffolds=False, mol_id_prefix=None):
     """
     Featurize molecules in input_filename using the given featurizer.
 
@@ -146,14 +149,16 @@ def main(featurizer_class, input_filename, output_filename,
         Compression level (0-9) to use with joblib.dump.
     smiles_hydrogens : bool, optional (default False)
         Whether to keep hydrogens when generating SMILES.
-    names : bool, optional (default False)
-        Whether to include molecule names in output.
+    include_smiles : bool, optional (default False)
+        Include SMILES in output.
     scaffolds : bool, optional (default False)
         Whether to include scaffolds in output.
     chiral_scaffods : bool, optional (default False)
         Whether to include chirality in scaffolds.
+    mol_id_prefix : str, optional
+        Prefix for molecule IDs.
     """
-    mols, mol_names = read_mols(input_filename)
+    mols, mol_ids = read_mols(input_filename, mol_id_prefix=mol_id_prefix)
 
     # get targets
     data = {}
@@ -161,9 +166,9 @@ def main(featurizer_class, input_filename, output_filename,
         targets = read_pickle(target_filename)
         if isinstance(targets, dict):
             mol_indices, target_indices = collate_mols(
-                mols, mol_names, targets['y'], targets['names'])
+                mols, mol_ids, targets['y'], targets['names'])
             mols = mols[mol_indices]
-            mol_names = mol_names[mol_indices]
+            mol_ids = mol_ids[mol_indices]
             targets = np.asarray(targets['y'])[target_indices]
         else:
             assert len(targets) == len(mols)
@@ -178,21 +183,19 @@ def main(featurizer_class, input_filename, output_filename,
 
     # fill in data container
     print "Saving results..."
+    data['mol_id'] = mol_ids
     data['features'] = features
-
-    # calculate SMILES
-    smiles = SmilesGenerator(remove_hydrogens=(not smiles_hydrogens))
-    data['smiles'] = np.asarray([smiles.get_smiles(mol) for mol in mols])
 
     # sanity checks
     assert data['features'].shape[0] == len(mols), (
         "Features do not match molecules.")
-    assert data['smiles'].shape[0] == len(mols), (
-        "SMILES do not match molecules.")
+    assert data['mol_id'].shape[0] == len(mols), (
+        "Molecule IDs do not match molecules.")
 
-    # names, scaffolds, args
-    if names:
-        data['names'] = mol_names
+    # smiles, scaffolds, args
+    if include_smiles:
+        smiles = SmilesGenerator(remove_hydrogens=(not smiles_hydrogens))
+        data['smiles'] = np.asarray([smiles.get_smiles(mol) for mol in mols])
     if scaffolds:
         data['scaffolds'] = get_scaffolds(mols, chiral_scaffolds)
 
@@ -266,7 +269,7 @@ def collate_mols(mols, mol_names, targets, target_names):
     return mol_indices, target_indices
 
 
-def read_mols(input_filename):
+def read_mols(input_filename, mol_id_prefix=None):
     """
     Read molecules from an input file and extract names.
 
@@ -276,17 +279,18 @@ def read_mols(input_filename):
         Filename containing molecules.
     """
     print "Reading molecules..."
-    reader = serial.MolReader()
-    reader.open(input_filename)
     mols = []
     names = []
-    for mol in reader.get_mols():
-        mols.append(mol)
-        if mol.HasProp('_Name'):
-            names.append(mol.GetProp('_Name'))
-        else:
-            names.append(None)
-    reader.close()
+    with serial.MolReader().open(input_filename) as reader:
+        for mol in reader.get_mols():
+            mols.append(mol)
+            if mol.HasProp('_Name'):
+                name = mol.GetProp('_Name')
+                if mol_id_prefix is not None:
+                    name = mol_id_prefix + name
+                names.append(name)
+            else:
+                names.append(None)
     mols = np.asarray(mols)
     names = np.asarray(names)
     return mols, names
@@ -354,7 +358,17 @@ if __name__ == '__main__':
     view_flags = {'retries': 1}
 
     # run main function
-    main(args.klass, args.input, args.output, args.targets,
-         vars(args.featurizer_kwargs), args.parallel, client_kwargs,
-         view_flags, args.compression_level, args.smiles_hydrogens, args.names,
-         args.scaffolds, args.chiral_scaffolds)
+    main(featurizer_class=args.klass,
+         input_filename=args.input,
+         output_filename=args.output,
+         target_filename=args.targets,
+         featurizer_kwargs=vars(args.featurizer_kwargs),
+         parallel=args.parallel,
+         client_kwargs=client_kwargs,
+         view_flags=view_flags,
+         compression_level=args.compression_level,
+         smiles_hydrogens=args.smiles_hydrogens,
+         include_smiles=args.include_smiles,
+         scaffolds=args.scaffolds,
+         chiral_scaffolds=args.chiral_scaffolds,
+         mol_id_prefix=args.mol_prefix)

--- a/vs_utils/scripts/featurize.py
+++ b/vs_utils/scripts/featurize.py
@@ -166,7 +166,7 @@ def main(featurizer_class, input_filename, output_filename,
         targets = read_pickle(target_filename)
         if isinstance(targets, dict):
             mol_indices, target_indices = collate_mols(
-                mols, mol_ids, targets['y'], targets['names'])
+                mols, mol_ids, targets['y'], targets['mol_id'])
             mols = mols[mol_indices]
             mol_ids = mol_ids[mol_indices]
             targets = np.asarray(targets['y'])[target_indices]

--- a/vs_utils/scripts/featurize.py
+++ b/vs_utils/scripts/featurize.py
@@ -219,7 +219,7 @@ def main(featurizer_class, input_filename, output_filename,
     write_output_file(df, output_filename, compression_level)
 
 
-def collate_mols(mols, mol_names, targets, target_names):
+def collate_mols(mols, mol_names, targets, target_ids):
     """
     Prune and reorder mols to match targets.
 
@@ -231,8 +231,8 @@ def collate_mols(mols, mol_names, targets, target_names):
         Molecule names.
     targets : array_like
         Targets.
-    target_names : array_like
-        Molecule names corresponding to targets.
+    target_ids : array_like
+        Molecule IDs corresponding to targets.
 
     Returns
     -------
@@ -245,10 +245,10 @@ def collate_mols(mols, mol_names, targets, target_names):
         for a molecule that has target data).
     """
     print "Collating molecules and targets..."
-    assert len(mols) == len(mol_names) and len(targets) == len(target_names)
+    assert len(mols) == len(mol_names) and len(targets) == len(target_ids)
 
     # make sure dtypes match for names so comparisons will work properly
-    target_names = np.asarray(target_names)
+    target_names = np.asarray(target_ids)
     mol_names = np.asarray(mol_names).astype(target_names.dtype)
 
     # sanity checks

--- a/vs_utils/scripts/tests/test_featurize.py
+++ b/vs_utils/scripts/tests/test_featurize.py
@@ -26,13 +26,13 @@ class TestFeaturize(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         smiles = ['CC(=O)OC1=CC=CC=C1C(=O)O',
                   'C[C@@H](C1=CC=C(C=C1)CC(C)C)C(=O)O']
-        self.names = ['aspirin', 'ibuprofen']
+        self.mol_ids = ['aspirin', 'ibuprofen']
         engine = conformers.ConformerGenerator(max_conformers=1)
         self.mols = []
         self.smiles = []  # use RDKit-generated SMILES
         for i in xrange(len(smiles)):
             mol = Chem.MolFromSmiles(smiles[i])
-            mol.SetProp('_Name', self.names[i])
+            mol.SetProp('_Name', self.mol_ids[i])
             self.mols.append(engine.generate_conformers(mol))
             self.smiles.append(Chem.MolToSmiles(mol, isomericSmiles=True,
                                                 canonical=True))
@@ -57,15 +57,15 @@ class TestFeaturize(unittest.TestCase):
 
         Parameters
         ----------
-        filenames : list
-            Filenames to delete.
+        filemol_ids : list
+            Filemol_ids to delete.
         """
         shutil.rmtree(self.temp_dir)
 
-    def check_output(self, featurize_args, shape, targets=None, names=None,
+    def check_output(self, featurize_args, shape, targets=None, mol_ids=None,
                      smiles=None, output_suffix='.pkl'):
         """
-        Check features shape, targets, and names.
+        Check features shape, targets, and mol_ids.
 
         Parameters
         ----------
@@ -77,8 +77,8 @@ class TestFeaturize(unittest.TestCase):
             Expected shape of features.
         targets : list, optional
             Expected targets. Defaults to self.targets.
-        names : list, optional
-            Expected names. Defaults to self.names.
+        mol_ids : list, optional
+            Expected mol_ids. Defaults to self.mol_ids.
         smiles : list, optional
             Expected SMILES. Defaults to self.smiles.
         output_suffix : str, optional (default '.pkl')
@@ -111,15 +111,15 @@ class TestFeaturize(unittest.TestCase):
         # check values
         if targets is None:
             targets = self.targets
-        if names is None:
-            names = self.names
+        if mol_ids is None:
+            mol_ids = self.mol_ids
         if smiles is None:
             smiles = self.smiles
         assert len(data) == shape[0]
         if len(shape) > 1:
             assert np.asarray(data.ix[0, 'features']).shape == shape[1:]
         assert np.array_equal(data['y'], targets), data['y']
-        assert np.array_equal(data['mol_id'], names), data['mol_id']
+        assert np.array_equal(data['mol_id'], mol_ids), data['mol_id']
         assert np.array_equal(data['smiles'], smiles), data['smiles']
 
         # return output in case anything else needs to be checked
@@ -209,11 +209,11 @@ class TestFeaturize(unittest.TestCase):
 
     def test_mol_id_prefix(self):
         """
-        Test that names are prepended with mol_id_prefix.
+        Test that mol_ids are prepended with mol_id_prefix.
         """
         prefix = 'CID'
-        for i, name in enumerate(self.names):
-          self.names[i] = prefix + name
+        for i, mol_id in enumerate(self.mol_ids):
+          self.mol_ids[i] = prefix + mol_id
         self.check_output(['--mol-prefix', prefix, 'circular', '--size', '512'],
                           (2, 512))
 
@@ -242,7 +242,7 @@ class TestFeaturize(unittest.TestCase):
         mol.SetProp('_Name', 'romosetron')
         AllChem.Compute2DCoords(mol)
         self.mols[1] = mol
-        self.names[1] = 'romosetron'
+        self.mol_ids[1] = 'romosetron'
         self.smiles[1] = Chem.MolToSmiles(mol, isomericSmiles=True)
 
         # write mols
@@ -270,12 +270,12 @@ class TestFeaturize(unittest.TestCase):
         """
 
         # write targets
-        targets = {'names': ['ibuprofen'], 'y': [0]}
+        targets = {'mol_id': ['ibuprofen'], 'y': [0]}
         write_pickle(targets, self.targets_filename)
 
         # run script
         self.check_output(['circular'], (1, 2048), targets=targets['y'],
-                          names=targets['names'], smiles=[self.smiles[1]])
+                          mol_ids=targets['mol_id'], smiles=[self.smiles[1]])
 
     def test_collate_mols2(self):
         """
@@ -283,7 +283,7 @@ class TestFeaturize(unittest.TestCase):
         """
 
         # write targets
-        targets = {'names': ['aspirin', 'ibuprofen'], 'y': [0, 1]}
+        targets = {'mol_id': ['aspirin', 'ibuprofen'], 'y': [0, 1]}
         write_pickle(targets, self.targets_filename)
 
         # write mols
@@ -294,7 +294,7 @@ class TestFeaturize(unittest.TestCase):
 
         # run script
         self.check_output(['circular'], (1, 2048), targets=[0],
-                          names=['aspirin'], smiles=[self.smiles[0]])
+                          mol_ids=['aspirin'], smiles=[self.smiles[0]])
 
     def test_collate_mols3(self):
         """
@@ -303,7 +303,7 @@ class TestFeaturize(unittest.TestCase):
         """
 
         # write targets
-        targets = {'names': ['ibuprofen', 'aspirin'], 'y': [1, 0]}
+        targets = {'mol_id': ['ibuprofen', 'aspirin'], 'y': [1, 0]}
         write_pickle(targets, self.targets_filename)
 
         # run script

--- a/vs_utils/scripts/tests/test_featurize.py
+++ b/vs_utils/scripts/tests/test_featurize.py
@@ -57,8 +57,8 @@ class TestFeaturize(unittest.TestCase):
 
         Parameters
         ----------
-        filemol_ids : list
-            Filemol_ids to delete.
+        filenames : list
+            Filenames to delete.
         """
         shutil.rmtree(self.temp_dir)
 


### PR DESCRIPTION
* Use generic mol_id in featurization output (a prefix can be given with `--mol-prefix`. Note that this change removes the 'names' field from the DataFrame and replaces it with 'mol_id'.
* Make SMILES calculation optional (off by default).